### PR TITLE
Processor.process() will process any additional Events returned by event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.DS_Store
 /.coverage
+/.idea
 /.tox
 /.venv
 /AUTHORS

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,9 @@ In this example, the ``test_prepare()`` handler function would be
 called first, followed by the ``test_auxiliary()`` handler function,
 and finally the ``test_run()`` handler function would be called.
 
+An event handler may optionally return a list of events, which will
+be processed in order.
+
 The Event Processor
 ===================
 
@@ -176,6 +179,10 @@ something like the following::
             # Process the event
             proc.process(ev)
 
+``Processor.process()`` returns ``None`` unless an event processor
+raises a ``evproc.StopProcessing`` exception initialized with a
+``retval``, in which case it returns the exception's ``retval``.
+
 Stop Processing
 ---------------
 
@@ -183,9 +190,14 @@ It may be necessary for one event processor to stop all event
 processing.  This could, for instance, be used by a processor that
 performs an authorization check if the event fails that check.  To
 allow this, an event processor may raise the ``evproc.StopProcessing``
-exception.  The ``StopProcessing`` exception may be initialized with a
-``retval`` parameter that will become the return value of
-``Processor.process()`` (which normally returns ``None``).
+exception.  When an event processor raises a ``StopProcessing``
+exception, no additional event processors will be called for that
+event.  If the ``StopProcessing`` exception is raised without a
+``retval``, yet-unprocessed events returned by prior event processors
+will still be processed.  If the ``StopProcessing`` exception is
+raised with a ``retval`` (even if ``None``), ``Processor.process()``
+will immediately return the exception's ``retval``, and yet-unprocessed
+events returned by prior event processors will not be processed.
 
 Conclusion
 ==========

--- a/evproc/exc.py
+++ b/evproc/exc.py
@@ -14,6 +14,9 @@
 #    governing permissions and limitations under the License.
 
 
+_unset = object()
+
+
 class EventException(Exception):
     """
     Base class for all ``evproc`` exceptions.
@@ -47,7 +50,7 @@ class StopProcessing(Exception):
     event processing.
     """
 
-    def __init__(self, retval=None):
+    def __init__(self, retval=_unset):
         """
         Initialize a ``StopProcessing`` exception.
 

--- a/tests/unit/test_exc.py
+++ b/tests/unit/test_exc.py
@@ -22,7 +22,7 @@ class StopProcessingTest(unittest.TestCase):
     def test_init_no_args(self):
         ex = exc.StopProcessing()
 
-        self.assertEqual(ex.retval, None)
+        self.assertEqual(ex.retval, exc._unset)
 
     def test_init_with_args(self):
         ex = exc.StopProcessing('retval')


### PR DESCRIPTION
An event handler may return an Event or list (or other iterable) of Events, in which case such event(s) is/are added to a queue of Events to be processed after completion of all processing of the current event.
